### PR TITLE
Include cracklib packages

### DIFF
--- a/mkosi.default
+++ b/mkosi.default
@@ -51,6 +51,8 @@ Packages=
     openssh-clients
     openssh-server
     passwd
+    cracklib
+    cracklib-dicts
     pciutils
     rootfiles
     rpm

--- a/mkosi.default
+++ b/mkosi.default
@@ -28,6 +28,8 @@ Packages=
     binutils
     btrfs-progs
     cloud-utils-growpart
+    cracklib
+    cracklib-dicts    
     dhcp-client
     diffutils
     dosfstools
@@ -51,8 +53,6 @@ Packages=
     openssh-clients
     openssh-server
     passwd
-    cracklib
-    cracklib-dicts
     pciutils
     rootfiles
     rpm


### PR DESCRIPTION
passwd uses cracklib when changing or setting a user's password, and emits strange warnings when either of these packages are missing.