### PR TITLE
Add missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Creates a Fedora usb drive that will boot on Apple M-series systems
 
 ## Fedora Package Install
-```dnf install arch-install-scripts bubblewrap gdisk mkosi pandoc rsync systemd-container```
+```dnf install arch-install-scripts bubblewrap dosfstools e2fsprogs gdisk mkosi openssl pandoc rsync systemd-container```
 
 #### Notes
 


### PR DESCRIPTION
`dosfstools` and `e2fsprogs` should already be installed by default in a typical Fedora installation, but there's no harm to be explicit here.

`openssl` is not installed by default, so it's definitely necessary to list it here.