### PR TITLE
fix sdhci-pci bootloop

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -225,6 +225,10 @@ install_usb() {
     arch-chroot $mnt_usb setfiles -F -p -c /etc/selinux/targeted/policy/policy.* -e /proc -e /sys -e /dev /etc/selinux/targeted/contexts/files/file_contexts /
     arch-chroot $mnt_usb setfiles -F -p -c /etc/selinux/targeted/policy/policy.* -e /proc -e /sys -e /dev /etc/selinux/targeted/contexts/files/file_contexts /boot
 
+    echo "### Fix sdhci_pci problem"
+    arch-chroot $mnt_usb systemd-hwdb update
+    arch-chroot $mnt_usb dracut --regenerate-all --force
+
     ###### post-install cleanup ######
     echo -e '\n### Cleanup'
     rm -f  $mnt_usb/etc/kernel/{entry-token,install.conf}

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -40,6 +40,7 @@ Packages=
     dracut-asahi
     e2fsprogs
     efivar
+    fedora-asahi-remix-scripts
     findutils
     grub2-efi-aa64
     grub2-efi-aa64-modules


### PR DESCRIPTION
With this changes, the created USB worked for me, but I'm not really sure it it's the correct way to implement it.

I've also seen this errors when creating the USB drive:

```
### Fix sdhci_pci problem
dracut[E]: No '/dev/log' or 'logger' included for syslog logging
dracut[E]: Module 'systemd-pcrphase' depends on 'tpm2-tss', which can't be installed
dracut[E]: Module 'systemd-pcrphase' depends on 'tpm2-tss', which can't be installed
```

Fixes #36